### PR TITLE
Bug Fix: use the expires field to determine token validity

### DIFF
--- a/django_expiring_token/authentication.py
+++ b/django_expiring_token/authentication.py
@@ -9,15 +9,9 @@ from django_expiring_token.models import ExpiringToken
 from django_expiring_token.settings import custom_settings
 
 
-def expires_in(token):
-    time_elapsed = timezone.now() - token.created
-    left_time = custom_settings.EXPIRING_TOKEN_DURATION - time_elapsed
-    return left_time
-
-
 # token checker if token expired or not
 def is_token_expired(token):
-    return expires_in(token) < timedelta(seconds=0)
+    return token.expires - timezone.now() < timedelta(seconds=0)
 
 
 # if token is expired new token will be established

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,6 +1,8 @@
 from datetime import timedelta
 
 SECRET_KEY = 'fake-key'
+# token expiry time used during tests
+EXPIRING_TOKEN_DURATION = timedelta(seconds=0.1)
 
 MIDDLEWARE_CLASSES = [
     'django.middleware.common.CommonMiddleware',

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -64,13 +64,12 @@ class ExpiringTokenAuthenticationTestCase(TestCase):
 
     def test_expired_token(self):
         """Check that an expired token cannot authenticate."""
-        # Crude, but necessary as auto_now_add field can't be changed.
-        with self.settings(EXPIRING_TOKEN_DURATION=timedelta(milliseconds=1)):
-            sleep(0.001)
+        # let the token expire
+        sleep(0.1)
 
-            try:
-                self.test_instance.authenticate_credentials(self.key)
-            except AuthenticationFailed as e:
-                self.assertEqual(e.__str__(), 'The Token is expired')
-            else:
-                self.fail("AuthenticationFailed not raised.")
+        try:
+            self.test_instance.authenticate_credentials(self.key)
+        except AuthenticationFailed as e:
+            self.assertEqual(e.__str__(), 'The Token is expired')
+        else:
+            self.fail("AuthenticationFailed not raised.")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -35,6 +35,6 @@ class ExpiringTokenAuthenticationTestCase(TestCase):
         self.assertFalse(is_token_expired(self.token))
 
     def test_expired_token(self):
-        with self.settings(EXPIRING_TOKEN_DURATION=timedelta(milliseconds=1)):
-            sleep(0.005)
-            self.assertTrue(is_token_expired(self.token))
+        # let the token expire
+        sleep(0.1)
+        self.assertTrue(is_token_expired(self.token))

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -82,9 +82,9 @@ class ExpiringTokenAuthenticationTestCase(TestCase):
 
         data = {'username': 'test_username', 'password': 'test_password'}
 
-        with self.settings(EXPIRING_TOKEN_DURATION=timedelta(milliseconds=1)):
-            sleep(0.005)
-            resp = self.client.post(reverse('obtain-token'), data)
+        # let the token expire
+        sleep(0.5)
+        resp = self.client.post(reverse('obtain-token'), data)
 
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
@@ -93,4 +93,3 @@ class ExpiringTokenAuthenticationTestCase(TestCase):
         self.assertEqual(token.user, self.user)
         self.assertEqual(resp.data['token'], token.key)
         self.assertTrue(key_1 != key_2)
-


### PR DESCRIPTION
The existing implementation updates the `expires` field but do not uses it to check the token validity. Commit fixes this problem in `is_token_expired` method. 

There is a problem in the tests. The `setUp` method is called before execution of any tests. Setup method creates an instance of `ExpiringTokenAuthentication` class. This instance has the default `EXPIRING_TOKEN_DURATION` value which is 1 day. The test methods  calls `self.settings` to override the value but it goes in vain because instance has already been created by then. I have also fixed this problem in the tests. 

